### PR TITLE
fix: a werid bug `VmRevertReasonParsingResult`

### DIFF
--- a/bootloader/bootloader.yul
+++ b/bootloader/bootloader.yul
@@ -542,7 +542,21 @@ object "Bootloader" {
                     debugLog("currentExpectedTxOffset", currentExpectedTxOffset)
                     debugLog("txDataOffset", txDataOffset)
 
-                    assertionError("Tx data offset is incorrect")
+                    let errMsgStart := mload(0x40)
+                    let expectedOffset := mload(currentExpectedTxOffset)
+                    let actualOffset := mload(add(txDataOffset, 32))
+
+                    // Store the expected and actual offsets in memory
+                    mstore(errMsgStart, expectedOffset)
+                    mstore(add(errMsgStart, 32), "|")
+                    mstore(add(errMsgStart, 33), actualOffset)
+
+                    // Prepend the concatenated string with its length
+                    let errMsgLen := add(65, 32)
+                    mstore(sub(errMsgStart, 32), errMsgLen)
+
+                    // Call the assertionError function with the concatenated string as an argument
+                    assertionError(errMsgStart)
                 }
 
                 currentExpectedTxOffset := validateAbiEncoding(txDataOffset)


### PR DESCRIPTION
problem I faced when running `zk server`:

> ERROR vm::vm: Observed error that should never happen: VmRevertReasonParsingResult { revert_reason: UnexpectedVMBehavior("Assertion error: Tx data offset is incorrect")

workaround:
    
open`etc/system-contracts/bootloader/bootloader.yul`
    
change Line: `//assertionError("Tx data offset is incorrect")` with
    
    let errMsgStart := mload(0x40)
    let expectedOffset := mload(currentExpectedTxOffset)
    let actualOffset := mload(add(txDataOffset, 32))
    
    // Store the expected and actual offsets in memory
    mstore(errMsgStart, expectedOffset)
    mstore(add(errMsgStart, 32), "|")
    mstore(add(errMsgStart, 33), actualOffset)
    
    // Prepend the concatenated string with its length
    let errMsgLen := add(65, 32)
    mstore(sub(errMsgStart, 32), errMsgLen)
    
    // Call the assertionError function with the concatenated string as an argument
    assertionError(errMsgStart)
    
    
then run `zk clean --contracts && zk init && zk server`
    
but I don’t know why it fixed the issue as the change is just to change the err msg